### PR TITLE
fix(yazi): update `exec` to `run` under help

### DIFF
--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -108,7 +108,7 @@ separator_style = { fg = "#434c5e" } # Muted dark
 
 [help]
 on = { fg = "#e8a2af" }                     # Soft red
-exec = { fg = "#a7c080" }                   # Soft Green
+run = { fg = "#a7c080" }                   # Soft Green
 desc = { fg = "#d3c6aa" }                   # Soft beige
 hovered = { bg = "#434c5e", bold = true }   # Muted dark background
 footer = { fg = "#2c313a", bg = "#d3c6aa" } # Dark background, Soft beige foreground


### PR DESCRIPTION
`exec` is not used in version 0.3.1

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the theme configuration by updating the key 'exec' to 'run' in the help section to reflect the correct usage in version 0.3.1.

Bug Fixes:
- Correct the key from 'exec' to 'run' in the help section of the theme configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->