### PR TITLE
add k9s skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Most are everforest dark soft.
 19. [VSCode](https://code.visualstudio.com/): please refer to [vscode-everforest](https://github.com/sainnhe/everforest-vscode).
 20. [zellij](zellij.dev): see the `zellij` folder.
 21. [SurfingKeys](https://github.com/brookhong/Surfingkeys): see the `SurfingKeys` folder.
+22. [k9s](https://k9scli.io/topics/skins/): see the `k9s` folder.
 
 # Contributing
 

--- a/k9s/everforest.yml
+++ b/k9s/everforest.yml
@@ -1,0 +1,108 @@
+
+# -----------------------------------------------------------------------------
+# Everforest Theme for K9s
+# -----------------------------------------------------------------------------
+# Color Palette:
+# #232A2E bg_dim
+# #2D353B bg0
+# #343F44 bg1
+# #3D484D bg2
+# #475258 bg3
+# #4F585E bg4
+# #56635f bg5
+# #543A48 bg_visual
+# #514045 bg_red
+# #425047 bg_green
+# #3A515D bg_blue
+# #4D4C43 bg_yellow
+# #D3C6AA fg
+# #E67E80 red
+# #E69875 orange
+# #DBBC7F yellow
+# #A7C080 green
+# #83C092 aqua
+# #7FBBB3 blue
+# #D699B6 purple
+# #7A8478 grey0
+# #859289 grey1
+# #9DA9A0 grey2
+# #A7C080 statusline1
+# #D3C6AA statusline2
+# #E67E80 statusline3
+# -----------------------------------------------------------------------------
+
+k9s:
+  body:
+    fgColor: '#D3C6AA'
+    bgColor: default
+
+  prompt:
+    bgColor: default
+
+  info:
+    fgColor: '#A7C080'
+    sectionColor: '#D3C6AA'
+
+  dialog:
+    bgColor: '#1E2326'
+    labelFgColor: '#D3C6AA'
+    fieldFgColor: '#D3C6AA'
+
+  frame:
+    border:
+      fgColor: default
+      focusColor: default
+
+    menu:
+      fgColor: '#7FBBB3'
+      keyColor: '#E69875'
+      numKeyColor: '#A7C080'
+
+    crumbs:
+      fgColor: '#D3C6AA'
+      bgColor: default
+
+    status:
+      newColor: '#D3C6AA'
+      modifyColor: '#7FBBB3'
+      addColor: '#7FBBB3'
+      errorColor: '#E67E80'
+      highlightcolor: '#E69875'
+      killColor: '#4F5B58'
+      completedColor: '#859289'
+
+    title:
+      fgColor: '#A7C080'
+      bgColor: default
+      highlightColor: '#E69875'
+      counterColor: default
+      filterColor: '#859289'
+
+  views:
+    table:
+      fgColor: '#A7C080'
+      bgColor: default
+      cursorColor: '#A7C080'
+      header:
+        fgColor: '#A7C080'
+        bgColor: default
+        sorterColor: '#E69875'
+
+    yaml:
+      keyColor: '#A7C080'
+      colonColor: default
+      valueColor: '#E69875'
+
+    logs:
+      fgColor: '#D3C6AA'
+      bgColor: default
+      indicator:
+        bgColor: default
+        toggleOnColor: default
+        toggleOffColor: default
+
+    charts:
+      bgColor: default
+
+    xray:
+      bgColor: default


### PR DESCRIPTION
@neuromaancer 
Added everforesty minimalist skin for k9s. Suggestions are welcome. 
<img width="1472" alt="image" src="https://github.com/user-attachments/assets/4b8db5f2-e966-4494-b7d4-4d3873706077">

## Summary by Sourcery

Add a new everforest minimalist skin for k9s and update the README to include this addition, enhancing the visual customization options for k9s users.

New Features:
- Introduce a new minimalist skin for k9s based on the everforest theme, providing a visually cohesive and customizable interface for users.

Documentation:
- Update the README.md to include a reference to the new k9s skin, directing users to the appropriate folder for more information.