### PR TITLE
Fix bat syntax

### DIFF
--- a/bat/everforest-soft.tmTheme
+++ b/bat/everforest-soft.tmTheme
@@ -46,3 +46,5 @@
     <string>4d0379b5-ef82-467b-b8b8-365889420646</string>
     <key>colorSpaceName</key>
     <string>sRGB</string>
+  </dict>
+</plist>


### PR DESCRIPTION
Adds closing tags which fixes syntax

Syntax errors looked something like this:
```sh
➜ batcat cache --build                             
Failed to load one or more themes from '/home/me/.config/bat/themes' (reason: 'Invalid syntax theme settings')
No syntaxes were found in '/home/me/.config/bat/syntaxes', using the default set.
Writing theme set to /home/mecache/bat/themes.bin ... okay
Writing syntax set to /home/me/.cache/bat/syntaxes.bin ... okay
Writing metadata to folder /home/me/.cache/bat ... okay
```

Fixes #9

## Summary by Sourcery

Bug Fixes:
- Fix syntax errors in the 'everforest-soft.tmTheme' file by adding missing closing tags.

## Summary by Sourcery

Bug Fixes:
- Fix syntax errors in the 'everforest-soft.tmTheme' file by adding missing closing tags.