### PR TITLE
Add eza

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Everforest is an elegant color scheme with comfortable colors. While not as popu
 - **bat**: See [bat](./bat/) folder
 - **bottom**: See [bottom](./bottom/) folder
 - **broot**: See [broot](./broot/) folder
+- **eza**: See [eza](./eza/) folder
 - **k9s**: See [k9s](,/k9s) folder
 - **Starship**: See [starship](./starship/) folder
 - **tmux**: Available via [tmux-everforest](https://github.com/TanglingTreats/tmux-everforest)

--- a/eza/theme.yml
+++ b/eza/theme.yml
@@ -1,0 +1,123 @@
+colourful: true
+
+# Everforest Medium Palette
+# Background: #2d353b
+# Foreground: #d3c6aa
+# Black: #343f44
+# Red: #e67e80
+# Green: #a7c080
+# Yellow: #dbbc7f
+# Blue: #7fbbb3
+# Magenta: #d699b6
+# Cyan: #83c092
+# White: #d3c6aa
+# Gray: #859289
+# Bright Black: #475258
+# Bright Red: #e67e80
+# Bright Green: #a7c080
+# Bright Yellow: #dbbc7f
+# Bright Blue: #7fbbb3
+# Bright Magenta: #d699b6
+# Bright Cyan: #83c092
+# Bright White: #d3c6aa
+
+filekinds:
+  normal: { foreground: "#d3c6aa" }
+  directory: { foreground: "#e69875" }
+  symlink: { foreground: "#859289" }
+  pipe: { foreground: "#475258" }
+  block_device: { foreground: "#e67e80" }
+  char_device: { foreground: "#dbbc7f" }
+  socket: { foreground: "#343f44" }
+  special: { foreground: "#d699b6" }
+  executable: { foreground: "#a7c080" }
+  mount_point: { foreground: "#475258" }
+
+perms:
+  user_read: { foreground: "#859289" }
+  user_write: { foreground: "#475258" }
+  user_execute_file: { foreground: "#a7c080" }
+  user_execute_other: { foreground: "#a7c080" }
+  group_read: { foreground: "#859289" }
+  group_write: { foreground: "#475258" }
+  group_execute: { foreground: "#a7c080" }
+  other_read: { foreground: "#859289" }
+  other_write: { foreground: "#475258" }
+  other_execute: { foreground: "#a7c080" }
+  special_user_file: { foreground: "#d699b6" }
+  special_other: { foreground: "#475258" }
+  attribute: { foreground: "#859289" }
+
+size:
+  major: { foreground: "#859289" }
+  minor: { foreground: "#e69875" }
+  number_byte: { foreground: "#859289" }
+  number_kilo: { foreground: "#859289" }
+  number_mega: { foreground: "#83c092" }
+  number_giga: { foreground: "#d699b6" }
+  number_huge: { foreground: "#d699b6" }
+  unit_byte: { foreground: "#859289" }
+  unit_kilo: { foreground: "#83c092" }
+  unit_mega: { foreground: "#d699b6" }
+  unit_giga: { foreground: "#d699b6" }
+  unit_huge: { foreground: "#e69875" }
+
+users:
+  user_you: { foreground: "#dbbc7f" }
+  user_root: { foreground: "#e67e80" }
+  user_other: { foreground: "#d699b6" }
+  group_yours: { foreground: "#859289" }
+  group_other: { foreground: "#475258" }
+  group_root: { foreground: "#e67e80" }
+
+links:
+  normal: { foreground: "#e69875" }
+  multi_link_file: { foreground: "#83c092" }
+
+git:
+  new: { foreground: "#a7c080" }
+  modified: { foreground: "#dbbc7f" }
+  deleted: { foreground: "#e67e80" }
+  renamed: { foreground: "#83c092" }
+  typechange: { foreground: "#d699b6" }
+  ignored: { foreground: "#475258" }
+  conflicted: { foreground: "#e67e80" }
+
+git_repo:
+  branch_main: { foreground: "#859289" }
+  branch_other: { foreground: "#d699b6" }
+  git_clean: { foreground: "#a7c080" }
+  git_dirty: { foreground: "#e67e80" }
+
+security_context:
+  colon: { foreground: "#859289" }
+  user: { foreground: "#e69875" }
+  role: { foreground: "#d699b6" }
+  typ: { foreground: "#475258" }
+  range: { foreground: "#d699b6" }
+
+file_type:
+  image: { foreground: "#dbbc7f" }
+  video: { foreground: "#e67e80" }
+  music: { foreground: "#e69875" }
+  lossless: { foreground: "#475258" }
+  crypto: { foreground: "#343f44" }
+  document: { foreground: "#859289" }
+  compressed: { foreground: "#d699b6" }
+  temp: { foreground: "#e67e80" }
+  compiled: { foreground: "#83c092" }
+  build: { foreground: "#475258" }
+  source: { foreground: "#a7c080" }
+
+punctuation: { foreground: "#859289" }
+date: { foreground: "#83c092" }
+inode: { foreground: "#859289" }
+blocks: { foreground: "#859289" }
+header: { foreground: "#859289" }
+octal: { foreground: "#e69875" }
+flags: { foreground: "#d699b6" }
+
+symlink_path: { foreground: "#e69875" }
+control_char: { foreground: "#83c092" }
+broken_symlink: { foreground: "#e67e80" }
+broken_path_overlay: { foreground: "#859289" }


### PR DESCRIPTION
Added theme for eza, alternative for ls commands. The orange for filenames might be a bit too aggressive, can be replaced with a variant of green or blue. I haven't made my choice yet as I just switched to everforest. 

ls:
<img width="543" alt="Screenshot 2025-05-08 at 18 59 06" src="https://github.com/user-attachments/assets/19d04ff0-71df-4e0a-83b2-0638121a361b" />

tree: 
<img width="543" alt="Screenshot 2025-05-08 at 18 59 15" src="https://github.com/user-attachments/assets/1cb7f9bc-2a1f-4956-bec6-57e3fa170213" />

## Summary by Sourcery

Add Everforest theme configuration for eza, a modern replacement for ls command

New Features:
- Added theme configuration for eza with Everforest color palette

Documentation:
- Updated README.md to include eza in the list of themed tools